### PR TITLE
GitLab fixes

### DIFF
--- a/PlasterTemplate/PlasterTemplates/GitLab/psake.ps1
+++ b/PlasterTemplate/PlasterTemplates/GitLab/psake.ps1
@@ -201,8 +201,8 @@ Task BuildDocs -depends Build {
         LinkMode       = 'Automatic'
         LinkPattern    = @{
             FirstRelease  = "<%= $PLASTER_PARAM_GitLabURL %>/<%= $PLASTER_PARAM_GitLabUserName %>/$env:BHProjectName/tree/{CUR}"
-            NormalRelease = "<%= $PLASTER_PARAM_GitLabURL %>/<%= $PLASTER_PARAM_GitLabUserName %>/$env:BHProjectName/compare/{PREV}..{CUR}"
-            Unreleased    = "<%= $PLASTER_PARAM_GitLabURL %>/<%= $PLASTER_PARAM_GitLabUserName %>/$env:BHProjectName/compare/{CUR}..HEAD"
+            NormalRelease = "<%= $PLASTER_PARAM_GitLabURL %>/<%= $PLASTER_PARAM_GitLabUserName %>/$env:BHProjectName/compare/{PREV}...{CUR}"
+            Unreleased    = "<%= $PLASTER_PARAM_GitLabURL %>/<%= $PLASTER_PARAM_GitLabUserName %>/$env:BHProjectName/compare/{CUR}...HEAD"
         }
     }
     Update-Changelog @Params

--- a/PlasterTemplate/PlasterTemplates/GitLab/settings.json
+++ b/PlasterTemplate/PlasterTemplates/GitLab/settings.json
@@ -1,7 +1,7 @@
 // Place your settings in this file to overwrite default and user settings.
 {
   "powershell.codeFormatting.preset": "Stroustrup",
-  "editor.formatOnSave": true,
+  "editor.formatOnSave": false,
   "editor.insertSpaces": true,
   "editor.tabSize": 4,
   "files.insertFinalNewline": true,

--- a/PlasterTemplate/PlasterTemplates/GitLab/template.psm1
+++ b/PlasterTemplate/PlasterTemplates/GitLab/template.psm1
@@ -15,5 +15,11 @@ ForEach ($Folder in $FunctionFolders) {
         }
     }
 }
-$publicFunctions = (Get-ChildItem -Path "$PSScriptRoot\Public" -Filter '*.ps1').BaseName
+If (Test-Path -Path "$PSScriptRoot\Public") {
+    $publicFunctions = (Get-ChildItem -Path "$PSScriptRoot\Public" -Filter '*.ps1').BaseName
+}
+else {
+    $publicFunctions = (Get-ChildItem -Path "$PSScriptRoot" -Filter '*.ps1').BaseName
+}
+
 Export-ModuleMember -Function $publicFunctions

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Do you want to deploy docs with mkDocs?
 [No] Do not deploy docs with mkDocs [Yes] Deploy docs with mkDocs [?] Help (default is "No"): yes
 ```
 
-Note: If you choose to deploy docs with mkDocs, you will need to ensure that your GitLab-CI running has access to a Personal Access Token via a variable.
+**Note:** If you choose to deploy docs with mkDocs, you will need to ensure that your GitLab-CI running has access to a Personal Access Token via a variable.
 
 
 At this point it will create your module.
@@ -55,5 +55,5 @@ To create a deployment you need to tag a commit with the release version and the
 git tag 0.1.0
 git push origin 0.1.0
 ```
-To view the coverage report as a badge in the readme, you need to update your "Test coverage parsing" setting at Settings > CI/CD > General pipelines for your repository.
+To view the coverage report as a badge in the readme of your project, you need to update your "Test coverage parsing" setting at Settings > CI/CD > General pipelines for your repository.
 <!-- Add recommended regex settings for "'/^Covered (\d+.\d+\%) of \d+ analyzed Commands in \d+ Files\.$/'" here. -->

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Do you want to deploy docs with mkDocs?
 [No] Do not deploy docs with mkDocs [Yes] Deploy docs with mkDocs [?] Help (default is "No"): yes
 ```
 
-If you choose to deploy docs with mkDocs, you will need to ensure that your GitLab-CI running has access to a Personal Access Token via a variable.
+Note: If you choose to deploy docs with mkDocs, you will need to ensure that your GitLab-CI running has access to a Personal Access Token via a variable.
 
 
 At this point it will create your module.
@@ -55,3 +55,5 @@ To create a deployment you need to tag a commit with the release version and the
 git tag 0.1.0
 git push origin 0.1.0
 ```
+To view the coverage report as a badge in the readme, you need to update your "Test coverage parsing" setting at Settings > CI/CD > General pipelines for your repository.
+<!-- Add recommended regex settings for "'/^Covered (\d+.\d+\%) of \d+ analyzed Commands in \d+ Files\.$/'" here. -->

--- a/README.md
+++ b/README.md
@@ -55,5 +55,4 @@ To create a deployment you need to tag a commit with the release version and the
 git tag 0.1.0
 git push origin 0.1.0
 ```
-To view the coverage report as a badge in the readme of your project, you need to update your "Test coverage parsing" setting at Settings > CI/CD > General pipelines for your repository.
-<!-- Add recommended regex settings for "'/^Covered (\d+.\d+\%) of \d+ analyzed Commands in \d+ Files\.$/'" here. -->
+To view the coverage report for all commits as a badge in the readme of your project, you need to update your "Test coverage parsing" setting at Settings > CI/CD > General pipelines for your repository. The regex for this can be found in the .gitlab-ci.yml file, near the bottom. You can find more information [here](https://docs.gitlab.com/ee/ci/yaml/#coverage).


### PR DESCRIPTION
Couple more fixes for the Gitlab template. Including:

1) Check for the \Public path, and if it does not exist, default to $PSScriptRoot

2) Fix wording of README, specifically calling out the note about needing a Personal Access Token for deploying documentation

3) Add a note to the README about setting up the test coverage parsing regex.

Also need to figure out the exact regex needed to parse the coverage message, however, I do not have a working Gitlab instance to test with at the moment.